### PR TITLE
Add ColorAddFunction and ColorForm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@octokit/rest": "^20.1.0",
         "dotenv": "^16.4.5",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "uid": "^2.0.2"
       },
       "devDependencies": {
         "@types/react": "^18.2.66",
@@ -892,6 +893,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -4248,6 +4258,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/uid": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/uid/-/uid-2.0.2.tgz",
+      "integrity": "sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/csprng": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "@octokit/rest": "^20.1.0",
     "dotenv": "^16.4.5",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "uid": "^2.0.2"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,23 @@
 import { initialColors } from "./lib/colors";
 import Color from "./Components/Color/Color";
 import "./App.css";
+import ColorForm from "./Components/ColorForm/ColorForm.jsx";
+import { uid } from "uid";
+import { useState } from "react";
 
 function App() {
+  const [colors, setColors] = useState(initialColors);
+
+  function handleSubmit(newColor) {
+    setColors([{ id: uid(), ...newColor }, ...colors]);
+  }
+
   return (
     <>
       <h1>Theme Creator</h1>
+      <ColorForm onSubmit={handleSubmit} />
 
-      {initialColors.map((color) => {
+      {colors.map((color) => {
         return <Color key={color.id} color={color} />;
       })}
     </>

--- a/src/Components/ColorForm/ColorForm.css
+++ b/src/Components/ColorForm/ColorForm.css
@@ -1,0 +1,13 @@
+
+
+export default function ColorForm() {
+    return (
+
+      <form>
+      <label for="color">Your Color:</label>
+      <input type="text" id="color" name="color">
+      <input type="submit">
+      </form>
+
+    );
+  }

--- a/src/Components/ColorForm/ColorForm.jsx
+++ b/src/Components/ColorForm/ColorForm.jsx
@@ -1,0 +1,47 @@
+import ColorInput from "../ColorInput/ColorInput/";
+import "./ColorForm.css";
+
+export default function ColorForm({
+  onSubmit,
+  initialData = {
+    role: "Color Name",
+    hex: "#000000",
+    contrastText: "#ffffff",
+  },
+}) {
+  function handleSubmit(event) {
+    event.preventDefault();
+    const formData = new FormData(event.target);
+    const data = Object.fromEntries(formData);
+    onSubmit(data);
+  }
+
+  return (
+    <form className="color-form" onSubmit={handleSubmit}>
+      <label htmlFor="role">
+        Role
+        <br />
+        <input
+          type="text"
+          id="role"
+          name="role"
+          defaultValue={initialData.role}
+        />
+      </label>
+      <br />
+      <label htmlFor="hex">
+        Hex
+        <br />
+        <ColorInput id="hex" defaultValue={initialData.hex} />
+      </label>
+      <br />
+      <label htmlFor="contrastText">
+        Contrast Text
+        <br />
+        <ColorInput id="contrastText" defaultValue={initialData.contrastText} />
+      </label>
+      <br />
+      <button>ADD COLOR</button>
+    </form>
+  );
+}

--- a/src/Components/ColorInput/ColorInput.jsx
+++ b/src/Components/ColorInput/ColorInput.jsx
@@ -1,0 +1,22 @@
+import { useState } from "react";
+
+export default function ColorInput({ id, defaultValue }) {
+  const [inputValue, setInputValue] = useState(defaultValue);
+
+  function handleInputValue(event) {
+    setInputValue(event.target.value);
+  }
+
+  return (
+    <>
+      <input
+        type="text"
+        id={id}
+        name={id}
+        value={inputValue}
+        onChange={handleInputValue}
+      />
+      <input type="color" value={inputValue} onChange={handleInputValue} />
+    </>
+  );
+}


### PR DESCRIPTION
    Users can input a role, hex value, and contrast text via a form to add a new color to the theme.
    The form should be prefilled with default values to guide user input.
    Upon submission, the new color is added to the top of the colors and is displayed on a color card to confirm addition.
    The inputs for hex and contrastText should include both color and text input types for easy and accurate color selection.
